### PR TITLE
Changed event class to match proposed UDP architecture.

### DIFF
--- a/src/sysc_3303_project/common/Event.java
+++ b/src/sysc_3303_project/common/Event.java
@@ -1,56 +1,46 @@
-/**
- * SYSC3303 Project
- * Group 1
- * @version 2.0
- */
 package sysc_3303_project.common;
 
+import java.io.Serializable;
 
-/**
- * @author Andrei Popescu
- *
- * An event class that holds the nessesary information to send events to
- *   other threads
- */
-public class Event<T> {
+public class Event<T> implements Serializable {
 	
+	private Subsystem destinationSubsystem;
+	private int destinationID;
+	private Subsystem sourceSubsystem;
+	private int sourceID;
 	private T eventType;
-	private Object senderObject;
-	private Object payloadObject;
+	private Serializable payload;
 	
-	/**
-	 * Creates an event with a given event type, source, and payload
-	 * @param type		T, enum for the type of request
-	 * @param sender	Object, the sender
-	 * @param payload	Object, payload to send
-	 */
-	public Event(T type, Object sender, Object payload) {
+	public Event(Subsystem dest, int destID, Subsystem src, int srcID, T type, Serializable payload) {
+		this.destinationSubsystem = dest;
+		this.destinationID = destID;
+		this.sourceSubsystem = src;
+		this.sourceID = srcID;
 		this.eventType = type;
-		this.senderObject = sender;
-		this.payloadObject = payload;
+		this.payload = payload;
 	}
 	
-	/**
-	 * Getter for the event type
-	 * @return	T, enum for the request type
-	 */
+	public Subsystem getDestinationSubsystem() {
+		return destinationSubsystem;
+	}
+	
+	public Subsystem getSourceSubsystem() {
+		return sourceSubsystem;
+	}
+	
+	public int getDestinationID() {
+		return destinationID;
+	}
+	
+	public int getSourceID() {
+		return sourceID;
+	}
+	
 	public T getEventType() {
 		return eventType;
 	}
 	
-	/**
-	 * Getter for the sender
-	 * @return	Object, the thing that sends the event
-	 */
-	public Object getSender() {
-		return senderObject;
-	}
-	
-	/**
-	 * Getter for the payload
-	 * @return	Object, a payload object
-	 */
-	public Object getPayload() {
-		return payloadObject;
+	public Serializable getPayload() {
+		return payload;
 	}
 }

--- a/src/sysc_3303_project/common/Subsystem.java
+++ b/src/sysc_3303_project/common/Subsystem.java
@@ -1,0 +1,7 @@
+package sysc_3303_project.common;
+
+public enum Subsystem {
+	FLOOR,
+	SCHEDULER,
+	ELEVATOR
+}

--- a/src/sysc_3303_project/scheduler_subsystem/Scheduler.java
+++ b/src/sysc_3303_project/scheduler_subsystem/Scheduler.java
@@ -6,6 +6,7 @@
 
 package sysc_3303_project.scheduler_subsystem;
 
+import sysc_3303_project.common.Direction;
 import sysc_3303_project.common.Event;
 import sysc_3303_project.common.EventBuffer;
 import sysc_3303_project.common.RequestData;
@@ -15,6 +16,7 @@ import sysc_3303_project.floor_subsystem.FloorEventType;
 import sysc_3303_project.scheduler_subsystem.states.SchedulerState;
 import sysc_3303_project.scheduler_subsystem.states.SchedulerWaitingState;
 
+import java.io.Serializable;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;


### PR DESCRIPTION
Breaks every class that constructed events, since constructor is different (includes unit tests). EventBuffer behavior is unchanged.