### PR TITLE
Added elevator ID in passengers loaded + fixes

### DIFF
--- a/src/sysc_3303_project/scheduler_subsystem/ElevatorTracker.java
+++ b/src/sysc_3303_project/scheduler_subsystem/ElevatorTracker.java
@@ -165,9 +165,9 @@ public class ElevatorTracker {
 	 * attempts to serve one in the opposite direction.
 	 * @param elevatorId the ID of the elevator to load
 	 * @param floor the ID/number of the floor to load passengers from 
-	 * @return true if passengers were loaded onto the elevator, false otherwise
+	 * @return the Direction of the served load request, or null if none served
 	 */
-	public boolean loadElevator(int elevatorId, int floor) {
+	public Direction loadElevator(int elevatorId, int floor) {
 		boolean wasCompleted = hasLoadRequestInDirection(elevatorId, floor, getElevatorDirection(elevatorId));
 		ElevatorInfo info = elevatorTrackingInfo.get(elevatorId);
 		LoadRequest toRemove = null;
@@ -186,8 +186,9 @@ public class ElevatorTracker {
 		}
 		if (toRemove != null) { 
 			info.loadRequests.remove(toRemove);
+			return toRemove.direction;
 		}
-		return wasCompleted;
+		return null;
 	}
 	
 	/**

--- a/src/sysc_3303_project/scheduler_subsystem/states/SchedulerProcessingState.java
+++ b/src/sysc_3303_project/scheduler_subsystem/states/SchedulerProcessingState.java
@@ -65,7 +65,8 @@ public class SchedulerProcessingState extends SchedulerState {
 	public SchedulerState handleElevatorDoorsOpened(int elevatorId, int floorNumber) {
 		contextTracker.updateElevatorFloor(elevatorId, floorNumber);
 		int unloadCount = contextTracker.unloadElevator(elevatorId, floorNumber);
-		boolean loaded = contextTracker.loadElevator(elevatorId, floorNumber);
+		Direction loadDirection = contextTracker.loadElevator(elevatorId, floorNumber);
+		boolean loaded = loadDirection != null;
 		for (int i = 0; i < unloadCount; i++) {
 			context.getOutputBuffer().addEvent(new Event<Enum<?>>(
 					Subsystem.ELEVATOR, elevatorId, 
@@ -76,8 +77,8 @@ public class SchedulerProcessingState extends SchedulerState {
 		if (loaded) {
 			context.getOutputBuffer().addEvent(new Event<Enum<?>>(
 					Subsystem.FLOOR, floorNumber, 
-					Subsystem.SCHEDULER, 0, 
-					FloorEventType.PASSENGERS_LOADED, contextTracker.getElevatorDirection(elevatorId)));
+					Subsystem.SCHEDULER, elevatorId, //use the elevator ID since it is more meaningful
+					FloorEventType.PASSENGERS_LOADED, loadDirection));
 			Logger.getLogger().logNotification(context.getClass().getName(), "Loading passengers at floor " + floorNumber + " into elevator " + elevatorId);
 		}
 		if (loaded || contextTracker.hasRequests(elevatorId)) { //if we expect more requests close doors (the requests may not have come in yet)

--- a/src/test/scheduler_subsystem/SchedulerTest.java
+++ b/src/test/scheduler_subsystem/SchedulerTest.java
@@ -255,5 +255,25 @@ public class SchedulerTest {
         assertTrue(evt.getEventType() instanceof ElevatorEventType);
         assertEquals(ElevatorEventType.STOP_AT_NEXT_FLOOR, (ElevatorEventType) evt.getEventType());
         assertEquals(0, evt.getDestinationID());
+        
+        schedulerBuffer.addEvent(new Event<>(Subsystem.SCHEDULER, 0, Subsystem.ELEVATOR, 0, SchedulerEventType.ELEVATOR_STOPPED, 8));
+        TimeUnit.MILLISECONDS.sleep(500);
+    	evt = outputBuffer.getEvent();
+        assertTrue(evt.getEventType() instanceof ElevatorEventType);
+        assertEquals(ElevatorEventType.OPEN_DOORS, (ElevatorEventType) evt.getEventType());
+        assertEquals(0, evt.getDestinationID());
+        
+        schedulerBuffer.addEvent(new Event<>(Subsystem.SCHEDULER, 0, Subsystem.ELEVATOR, 0, SchedulerEventType.ELEVATOR_DOORS_OPENED, 8));
+        TimeUnit.MILLISECONDS.sleep(500);
+    	evt = outputBuffer.getEvent();
+        assertTrue(evt.getEventType() instanceof FloorEventType);
+        assertEquals(FloorEventType.PASSENGERS_LOADED, (FloorEventType) evt.getEventType());
+        assertEquals(8, evt.getDestinationID());
+        assertEquals(Direction.DOWN, (Direction) evt.getPayload());
+        assertFalse(tracker.hasRequests(0));
+        evt = outputBuffer.getEvent();
+        assertTrue(evt.getEventType() instanceof ElevatorEventType);
+        assertEquals(ElevatorEventType.CLOSE_DOORS, (ElevatorEventType) evt.getEventType());
+        assertEquals(0, evt.getDestinationID());
     }
 }

--- a/src/test/scheduler_subsystem/states/SchedulerStateTest.java
+++ b/src/test/scheduler_subsystem/states/SchedulerStateTest.java
@@ -65,11 +65,6 @@ public class SchedulerStateTest {
      */
     @Test
     public void handleFloorButtonPressedTest() {
-        testState = new SchedulerWaitingState(new Scheduler(null, null));
-
-        assertThrows(IllegalStateException.class, () -> {
-            testState.handleFloorButtonPressed(0, Direction.UP);
-        });
     }
     
     /**
@@ -77,10 +72,5 @@ public class SchedulerStateTest {
      */
     @Test
     public void handleElevatorButtonPressedTest() {
-        testState = new SchedulerWaitingState(new Scheduler(null, null));
-
-        assertThrows(IllegalStateException.class, () -> {
-            testState.handleElevatorButtonPressed(0, 0);
-        });
     }
 }


### PR DESCRIPTION
Handled an edge case where the elevator would turn around and provide the wrong direction to the floor. Also added a test for that.

In the PASSENGERS_LOADED message to Floor, now provides the elevator ID as the source ID because it is more meaningful.