### PR TITLE
Elevator closing test

### DIFF
--- a/src/test/elevator_subsystem/states/ElevatorDoorsClosingStateTest.java
+++ b/src/test/elevator_subsystem/states/ElevatorDoorsClosingStateTest.java
@@ -14,9 +14,12 @@ import sysc_3303_project.elevator_subsystem.ElevatorEventType;
 import sysc_3303_project.elevator_subsystem.states.ElevatorDoorsClosedState;
 import sysc_3303_project.elevator_subsystem.states.ElevatorDoorsClosingState;
 import sysc_3303_project.elevator_subsystem.states.ElevatorState;
+import sysc_3303_project.scheduler_subsystem.Scheduler;
 import sysc_3303_project.scheduler_subsystem.SchedulerEventType;
 
 import static org.junit.jupiter.api.Assertions.*;
+
+import java.lang.reflect.Field;
 
 /**
  * @author Liam Gaudet and Ian Holmes
@@ -75,6 +78,16 @@ public class ElevatorDoorsClosingStateTest extends ElevatorStateTest{
         EventBuffer<ElevatorEventType> contextBuffer = new EventBuffer<>();
 
         Elevator testContext = new Elevator(schedulerBuffer, contextBuffer, 0);
+        Field elevatorFloorField;
+		try {
+			elevatorFloorField = Elevator.class.getDeclaredField("elevatorFloor");
+			elevatorFloorField.setAccessible(true);
+			elevatorFloorField.set(testContext, 2);
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail();
+		}
+        
         testContext.setFloor(2);
 
         ElevatorState testState = new ElevatorDoorsClosingState(testContext);


### PR DESCRIPTION
Used reflection to set floor where needed. NOTE: doors close test fails because it is wrongly defined - we should be expecting a return null NOT an error!  This might be an issue in the opening test as well.